### PR TITLE
v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.11.0] - 2021-12-28
+
+  - Removed steinbock version check
+  - Fix IMC panel preprocessing (channel order)
+  - Make CLI usable when using PyPI package install
+  - Renamed `--mask` and `--probab` parameters to `--masks` and `--probabs`, respectively 
+  - Clean histoCAT export file names
+  - Required `-o` parameter for data export
+
 ## [0.10.7] - 2021-12-27
 
   - Fix IMC panel preprocessing
@@ -263,6 +272,7 @@ Added:
 Initial release for beta testing
 
 
+[0.11.0]: https://github.com/BodenmillerGroup/steinbock/compare/v0.10.7...v0.11.0
 [0.10.7]: https://github.com/BodenmillerGroup/steinbock/compare/v0.10.6...v0.10.7
 [0.10.6]: https://github.com/BodenmillerGroup/steinbock/compare/v0.10.5...v0.10.6
 [0.10.5]: https://github.com/BodenmillerGroup/steinbock/compare/v0.10.4...v0.10.5

--- a/docs/cli/export.md
+++ b/docs/cli/export.md
@@ -22,7 +22,7 @@ This will create a histoCAT-compatible folder structure (defaults to `histocat`)
 
 To export specified object data from all images as a single .csv file:
 
-    steinbock export csv intensities regionprops
+    steinbock export csv intensities regionprops -o objects.csv
 
 This will collect object data from the `intensities` and `regionprops` directories and create a single object data table in [object data format](../file-types.md#object-data), with an additional first column indicating the source image.
 
@@ -30,17 +30,17 @@ This will collect object data from the `intensities` and `regionprops` directori
 
 To export specified object data from all images as a single .fcs file:
 
-    steinbock export fcs intensities regionprops
+    steinbock export fcs intensities regionprops -o objects.fcs
 
-This will collect object data from the `intensities` and `regionprops` directories and create a single FCS file (defaults to `objects.fcs`) using the [fcswrite](https://github.com/ZELLMECHANIK-DRESDEN/fcswrite) package.
+This will collect object data from the `intensities` and `regionprops` directories and create a single FCS file using the [fcswrite](https://github.com/ZELLMECHANIK-DRESDEN/fcswrite) package.
 
 ## AnnData
 
 To export specified object data to [AnnData](https://github.com/theislab/anndata):
 
-    steinbock export anndata --intensities intensities --data regionprops --neighbors neighbors
+    steinbock export anndata --intensities intensities --data regionprops --neighbors neighbors -o objects.h5ad
 
-This will generate a single .h5ad file (defaults to `objects.h5ad`), with object intensities as main data, object regionprops as observation annotations, and neighbors as pairwise observation annotations (adjacency matrix in `adj`, distances in `dists`).
+This will generate a single .h5ad file, with object intensities as main data, object regionprops as observation annotations, and neighbors as pairwise observation annotations (adjacency matrix in `adj`, distances in `dists`).
 
 !!! note "AnnData file format"
     To export the data as .loom or .zarr, specify `--format loom` or `--format zarr`, respectively.

--- a/docs/install-docker.md
+++ b/docs/install-docker.md
@@ -36,7 +36,7 @@ In principle, the *steinbock* Docker container can be run on any Docker-enabled 
 
 For reproducibility, it is recommended to always pull a specific release, e.g.:
 
-    docker run ghcr.io/bodenmillergroup/steinbock:0.10.7
+    docker run ghcr.io/bodenmillergroup/steinbock:0.11.0
 
 [Bind mounts](https://docs.docker.com/storage/bind-mounts/) can be used to make data from the host system available to the Docker container (see below). Commands that launch a graphical user interface may require further system configuration and additional arguments to `docker run` as outlined in the following.
 
@@ -45,11 +45,11 @@ For reproducibility, it is recommended to always pull a specific release, e.g.:
 
 On the command line, use the following command to run the *steinbock* Docker container:
 
-    docker run -v "C:\Data":/data ghcr.io/bodenmillergroup/steinbock:0.10.7
+    docker run -v "C:\Data":/data ghcr.io/bodenmillergroup/steinbock:0.11.0
 
-In the command above, adapt the bind mount path to your data/working directory (`C:\Data`) and the *steinbock* Docker container version (`0.10.7`) as needed. To simplify the use of the *steinbock* command-line interface, it is recommended to set up a `steinbock` command alias:
+In the command above, adapt the bind mount path to your data/working directory (`C:\Data`) and the *steinbock* Docker container version (`0.11.0`) as needed. To simplify the use of the *steinbock* command-line interface, it is recommended to set up a `steinbock` command alias:
 
-    doskey steinbock=docker run -v "C:\Data":/data ghcr.io/bodenmillergroup/steinbock:0.10.7 $*
+    doskey steinbock=docker run -v "C:\Data":/data ghcr.io/bodenmillergroup/steinbock:0.11.0 $*
 
 The created command alias is retained for the current session and enables running `steinbock` from the current command line without typing the full Docker command, for example:
 
@@ -62,11 +62,11 @@ The created command alias is retained for the current session and enables runnin
 
 On the terminal, use the following command to run the *steinbock* Docker container:
 
-    docker run -v /path/to/data:/data -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/steinbock/.Xauthority:ro -u $(id -u):$(id -g) -e DISPLAY ghcr.io/bodenmillergroup/steinbock:0.10.7
+    docker run -v /path/to/data:/data -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/steinbock/.Xauthority:ro -u $(id -u):$(id -g) -e DISPLAY ghcr.io/bodenmillergroup/steinbock:0.11.0
 
-In the command above, adapt the bind mount path to your data/working directory (`/path/to/data`) and the *steinbock* Docker container version (`0.10.7`) as needed. To simplify the use of the *steinbock* command-line interface, it is recommended to set up a `steinbock` command alias:
+In the command above, adapt the bind mount path to your data/working directory (`/path/to/data`) and the *steinbock* Docker container version (`0.11.0`) as needed. To simplify the use of the *steinbock* command-line interface, it is recommended to set up a `steinbock` command alias:
 
-    alias steinbock="docker run -v /path/to/data:/data -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/steinbock/.Xauthority:ro -u $(id -u):$(id -g) -e DISPLAY ghcr.io/bodenmillergroup/steinbock:0.10.7"
+    alias steinbock="docker run -v /path/to/data:/data -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/steinbock/.Xauthority:ro -u $(id -u):$(id -g) -e DISPLAY ghcr.io/bodenmillergroup/steinbock:0.11.0"
 
 The created command alias is retained for the current session and enables running `steinbock` from the current terminal without typing the full Docker command, for example:
 
@@ -81,11 +81,11 @@ The created command alias is retained for the current session and enables runnin
 
 On the terminal, use the following command to run the *steinbock* Docker container (Docker must be running):
 
-    docker run -v /path/to/data:/data -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/steinbock/.Xauthority:ro -u $(id -u):$(id -g) -e DISPLAY=$(hostname):0 ghcr.io/bodenmillergroup/steinbock:0.10.7
+    docker run -v /path/to/data:/data -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/steinbock/.Xauthority:ro -u $(id -u):$(id -g) -e DISPLAY=$(hostname):0 ghcr.io/bodenmillergroup/steinbock:0.11.0
 
-In the command above, adapt the bind mount path to your data/working directory (`/path/to/data`) and the *steinbock* Docker container version (`0.10.7`) as needed. To simplify the use of the *steinbock* command-line interface, it is recommended to set up a `steinbock` command alias:
+In the command above, adapt the bind mount path to your data/working directory (`/path/to/data`) and the *steinbock* Docker container version (`0.11.0`) as needed. To simplify the use of the *steinbock* command-line interface, it is recommended to set up a `steinbock` command alias:
 
-    alias steinbock="docker run -v /path/to/data:/data -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/steinbock/.Xauthority:ro -u $(id -u):$(id -g) -e DISPLAY=$(hostname):0 ghcr.io/bodenmillergroup/steinbock:0.10.7"
+    alias steinbock="docker run -v /path/to/data:/data -v /tmp/.X11-unix:/tmp/.X11-unix -v ~/.Xauthority:/home/steinbock/.Xauthority:ro -u $(id -u):$(id -g) -e DISPLAY=$(hostname):0 ghcr.io/bodenmillergroup/steinbock:0.11.0"
 
 The created command alias is retained for the current session and enables running `steinbock` from the current terminal without typing the full Docker command, for example:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 mkdocs-material==8.1.3
-mkdocstrings==0.16.2
+mkdocstrings==0.17.0
 mike==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ click==8.0.3
 # deepcell==0.11.0  # install manually first, to avoid version conflicts
 fcswrite==0.6.1
 h5py==3.2.1  # cellprofiler 4.2.1 requires 3.2.1 (note: deepcell 0.11.0 requires tensorflow ~=2.5.1, which requires ~=3.1.0)
-imageio==2.13.3
+imageio==2.13.5
 networkx==2.6.3
 numpy==1.21.5  # note: deepcell 0.11.0 technically requires <1.20.0
 opencv-contrib-python==4.5.4.60

--- a/steinbock/_cli/apps.py
+++ b/steinbock/_cli/apps.py
@@ -1,15 +1,10 @@
 import click
 import sys
 
+from pathlib import Path
+
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import (
-    cellprofiler_binary,
-    cellprofiler_plugin_dir,
-    check_x11,
-    ilastik_binary,
-    run_captured,
-    use_ilastik_env,
-)
+from steinbock._env import check_x11, run_captured, use_ilastik_env
 
 
 @click.group(
@@ -25,11 +20,18 @@ def apps_cmd_group():
     help="Run Ilastik (GUI requires X11)",
     add_help_option=False,
 )
+@click.option(
+    "--ilastik",
+    "ilastik_binary",
+    type=click.STRING,
+    default="/opt/ilastik/run_ilastik.sh",
+    show_default=True,
+    help="Ilastik binary",
+)
 @click.argument("ilastik_args", nargs=-1, type=click.UNPROCESSED)
-# @check_steinbock_version
 @check_x11
 @use_ilastik_env
-def ilastik_cmd(ilastik_args, ilastik_env):
+def ilastik_cmd(ilastik_binary, ilastik_args, ilastik_env):
     args = [ilastik_binary] + list(ilastik_args)
     result = run_captured(args, env=ilastik_env)
     sys.exit(result.returncode)
@@ -41,12 +43,29 @@ def ilastik_cmd(ilastik_args, ilastik_env):
     help="Run CellProfiler (GUI requires X11)",
     add_help_option=False,
 )
+@click.option(
+    "--cellprofiler",
+    "cellprofiler_binary",
+    type=click.STRING,
+    default="cellprofiler",
+    show_default=True,
+    help="CellProfiler binary",
+)
+@click.option(
+    "--plugins-directory",
+    "cellprofiler_plugin_dir",
+    type=click.Path(file_okay=False),
+    default="/opt/cellprofiler_plugins",
+    show_default=True,
+    help="Path to the CellProfiler plugin directory",
+)
 @click.argument("cellprofiler_args", nargs=-1, type=click.UNPROCESSED)
-# @check_steinbock_version
 @check_x11
-def cellprofiler_cmd(cellprofiler_args):
+def cellprofiler_cmd(
+    cellprofiler_binary, cellprofiler_plugin_dir, cellprofiler_args
+):
     args = [cellprofiler_binary] + list(cellprofiler_args)
-    if not any(arg.startswith("--plugins-directory") for arg in args):
+    if Path(cellprofiler_plugin_dir).exists():
         args.append(f"--plugins-directory={cellprofiler_plugin_dir}")
     result = run_captured(args)
     sys.exit(result.returncode)

--- a/steinbock/_cli/apps.py
+++ b/steinbock/_cli/apps.py
@@ -5,7 +5,6 @@ from steinbock._cli.utils import OrderedClickGroup
 from steinbock._env import (
     cellprofiler_binary,
     cellprofiler_plugin_dir,
-    check_steinbock_version,
     check_x11,
     ilastik_binary,
     run_captured,
@@ -27,7 +26,7 @@ def apps_cmd_group():
     add_help_option=False,
 )
 @click.argument("ilastik_args", nargs=-1, type=click.UNPROCESSED)
-@check_steinbock_version
+# @check_steinbock_version
 @check_x11
 @use_ilastik_env
 def ilastik_cmd(ilastik_args, ilastik_env):
@@ -43,7 +42,7 @@ def ilastik_cmd(ilastik_args, ilastik_env):
     add_help_option=False,
 )
 @click.argument("cellprofiler_args", nargs=-1, type=click.UNPROCESSED)
-@check_steinbock_version
+# @check_steinbock_version
 @check_x11
 def cellprofiler_cmd(cellprofiler_args):
     args = [cellprofiler_binary] + list(cellprofiler_args)

--- a/steinbock/_env.py
+++ b/steinbock/_env.py
@@ -6,8 +6,6 @@ import sys
 from functools import wraps
 from pathlib import Path
 
-from steinbock._version import version as steinbock_version
-
 ilastik_binary = "/opt/ilastik/run_ilastik.sh"
 cellprofiler_binary = "cellprofiler"
 cellprofiler_plugin_dir = "/opt/cellprofiler_plugins"
@@ -69,24 +67,24 @@ def use_ilastik_env(func):
     return use_ilastik_env_wrapper
 
 
-def check_steinbock_version(func):
-    @wraps(func)
-    def check_steinbock_version_wrapper(*args, **kwargs):
-        if Path(".steinbock_version").exists():
-            saved_steinbock_version = (
-                Path(".steinbock_version").read_text(encoding="utf-8").strip()
-            )
-            if saved_steinbock_version != steinbock_version:
-                click.echo(
-                    "WARNING: steinbock version change detected!\n"
-                    f"    previous: {saved_steinbock_version}\n"
-                    f"    current: {steinbock_version}",
-                    file=sys.stderr,
-                )
-        else:
-            Path(".steinbock_version").write_text(
-                steinbock_version, encoding="utf-8"
-            )
-        return func(*args, **kwargs)
+# def check_steinbock_version(func):
+#     @wraps(func)
+#     def check_steinbock_version_wrapper(*args, **kwargs):
+#         if Path(".steinbock_version").exists():
+#             saved_steinbock_version = (
+#                 Path(".steinbock_version").read_text(encoding="utf-8").strip()
+#             )
+#             if saved_steinbock_version != steinbock_version:
+#                 click.echo(
+#                     "WARNING: steinbock version change detected!\n"
+#                     f"    previous: {saved_steinbock_version}\n"
+#                     f"    current: {steinbock_version}",
+#                     file=sys.stderr,
+#                 )
+#         else:
+#             Path(".steinbock_version").write_text(
+#                 steinbock_version, encoding="utf-8"
+#             )
+#         return func(*args, **kwargs)
 
-    return check_steinbock_version_wrapper
+#     return check_steinbock_version_wrapper

--- a/steinbock/_env.py
+++ b/steinbock/_env.py
@@ -6,11 +6,6 @@ import sys
 from functools import wraps
 from pathlib import Path
 
-ilastik_binary = "/opt/ilastik/run_ilastik.sh"
-cellprofiler_binary = "cellprofiler"
-cellprofiler_plugin_dir = "/opt/cellprofiler_plugins"
-keras_models_dir = "/opt/keras/models"
-
 
 def run_captured(args, *popen_args, file=sys.stdout, **popen_kwargs):
     with subprocess.Popen(
@@ -32,22 +27,20 @@ def run_captured(args, *popen_args, file=sys.stdout, **popen_kwargs):
 def check_x11(func):
     @wraps(func)
     def check_x11_wrapper(*args, **kwargs):
-        display_var = "DISPLAY"
-        if display_var not in os.environ:
+        if "DISPLAY" not in os.environ:
             click.echo(
-                f"WARNING: X11 required; did you set ${display_var}?",
-                file=sys.stderr,
+                "WARNING: X11 required; did you set $DISPLAY?", file=sys.stderr
             )
         x11_path = Path("/tmp/.X11-unix")
         if not x11_path.exists():
             click.echo(
-                f"WARNING: X11 required; did you mount {x11_path}?",
+                f"WARNING: X11 required; did you bind-mount {x11_path}?",
                 file=sys.stderr,
             )
         xauth_path = Path("~/.Xauthority").expanduser()
         if not xauth_path.exists():
             click.echo(
-                f"WARNING: X11 required; did you mount {xauth_path}?",
+                f"WARNING: X11 required; did you bind-mount {xauth_path}?",
                 file=sys.stderr,
             )
         return func(*args, **kwargs)
@@ -65,26 +58,3 @@ def use_ilastik_env(func):
         return func(*args, **kwargs)
 
     return use_ilastik_env_wrapper
-
-
-# def check_steinbock_version(func):
-#     @wraps(func)
-#     def check_steinbock_version_wrapper(*args, **kwargs):
-#         if Path(".steinbock_version").exists():
-#             saved_steinbock_version = (
-#                 Path(".steinbock_version").read_text(encoding="utf-8").strip()
-#             )
-#             if saved_steinbock_version != steinbock_version:
-#                 click.echo(
-#                     "WARNING: steinbock version change detected!\n"
-#                     f"    previous: {saved_steinbock_version}\n"
-#                     f"    current: {steinbock_version}",
-#                     file=sys.stderr,
-#                 )
-#         else:
-#             Path(".steinbock_version").write_text(
-#                 steinbock_version, encoding="utf-8"
-#             )
-#         return func(*args, **kwargs)
-
-#     return check_steinbock_version_wrapper

--- a/steinbock/classification/_cli/ilastik.py
+++ b/steinbock/classification/_cli/ilastik.py
@@ -7,11 +7,7 @@ from pathlib import Path
 
 from steinbock import io
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import (
-    check_steinbock_version,
-    ilastik_binary,
-    use_ilastik_env,
-)
+from steinbock._env import ilastik_binary, use_ilastik_env
 from steinbock.classification import ilastik
 
 
@@ -107,7 +103,7 @@ def ilastik_cmd_group():
     help="Path to the Ilastik crop output directory",
 )
 @click.option("--seed", "seed", type=click.INT, help="Random seed")
-@check_steinbock_version
+# @check_steinbock_version
 def prepare_cmd(
     ilastik_project_file,
     img_dir,
@@ -216,7 +212,7 @@ def prepare_cmd(
     type=click.IntRange(min=0),
     help="Memory limit (in megabytes)",
 )
-@check_steinbock_version
+# @check_steinbock_version
 @use_ilastik_env
 def run_cmd(
     ilastik_project_file,
@@ -280,7 +276,7 @@ def run_cmd(
     type=click.STRING,
     help="Axis order of the existing crops (e.g. zyxc)",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def fix_cmd(
     ilastik_project_file,
     ilastik_crop_dir,

--- a/steinbock/classification/_cli/ilastik.py
+++ b/steinbock/classification/_cli/ilastik.py
@@ -263,7 +263,7 @@ def run_cmd(
     help="Path to the Ilastik crop directory",
 )
 @click.option(
-    "--probab",
+    "--probabs",
     "ilastik_probab_dir",
     type=click.Path(file_okay=False),
     default="ilastik_probabilities",

--- a/steinbock/classification/_cli/ilastik.py
+++ b/steinbock/classification/_cli/ilastik.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from steinbock import io
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import ilastik_binary, use_ilastik_env
+from steinbock._env import use_ilastik_env
 from steinbock.classification import ilastik
 
 
@@ -103,7 +103,6 @@ def ilastik_cmd_group():
     help="Path to the Ilastik crop output directory",
 )
 @click.option("--seed", "seed", type=click.INT, help="Random seed")
-# @check_steinbock_version
 def prepare_cmd(
     ilastik_project_file,
     img_dir,
@@ -177,6 +176,14 @@ def prepare_cmd(
     name="run", help="Run a pixel classification batch using Ilastik"
 )
 @click.option(
+    "--ilastik",
+    "ilastik_binary",
+    type=click.STRING,
+    default="/opt/ilastik/run_ilastik.sh",
+    show_default=True,
+    help="Ilastik binary",
+)
+@click.option(
     "--ilp",
     "ilastik_project_file",
     type=click.Path(exists=True, dir_okay=False),
@@ -212,9 +219,9 @@ def prepare_cmd(
     type=click.IntRange(min=0),
     help="Memory limit (in megabytes)",
 )
-# @check_steinbock_version
 @use_ilastik_env
 def run_cmd(
+    ilastik_binary,
     ilastik_project_file,
     ilastik_img_dir,
     ilastik_probab_dir,
@@ -276,7 +283,6 @@ def run_cmd(
     type=click.STRING,
     help="Axis order of the existing crops (e.g. zyxc)",
 )
-# @check_steinbock_version
 def fix_cmd(
     ilastik_project_file,
     ilastik_crop_dir,

--- a/steinbock/export/_cli/__init__.py
+++ b/steinbock/export/_cli/__init__.py
@@ -76,7 +76,7 @@ def ome_cmd(img_dir, panel_file, ome_dir):
     help="Path to the image directory",
 )
 @click.option(
-    "--mask",
+    "--masks",
     "mask_dir",
     type=click.Path(file_okay=False),
     default="masks",

--- a/steinbock/export/_cli/__init__.py
+++ b/steinbock/export/_cli/__init__.py
@@ -9,7 +9,6 @@ from steinbock import io
 from steinbock.export._cli.data import anndata_cmd, csv_cmd, fcs_cmd
 from steinbock.export._cli.graphs import graphs_cmd
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import check_steinbock_version
 
 
 @click.group(
@@ -46,7 +45,7 @@ def export_cmd_group():
     show_default=True,
     help="Path to the OME-TIFF export directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def ome_cmd(img_dir, panel_file, ome_dir):
     panel = io.read_panel(panel_file)
     channel_names = [
@@ -101,7 +100,7 @@ def ome_cmd(img_dir, panel_file, ome_dir):
     show_default=True,
     help="Path to the histoCAT export directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def histocat_cmd(img_dir, mask_dir, panel_file, histocat_dir):
     panel = io.read_panel(panel_file)
     channel_names = [

--- a/steinbock/export/_cli/__init__.py
+++ b/steinbock/export/_cli/__init__.py
@@ -1,5 +1,6 @@
 import click
 import numpy as np
+import re
 
 from pathlib import Path
 from tifffile import imwrite
@@ -117,6 +118,8 @@ def histocat_cmd(img_dir, mask_dir, panel_file, histocat_dir):
         histocat_img_dir = Path(histocat_dir) / img_file.stem
         histocat_img_dir.mkdir(exist_ok=True)
         for channel_name, channel_img in zip(channel_names, img):
+            channel_name = re.sub(r"\s*/\s*", "_", channel_name)
+            channel_name = re.sub(r"\s", "_", channel_name)
             imwrite(
                 histocat_img_dir / f"{channel_name}.tiff",
                 data=io._to_dtype(channel_img, np.float32),

--- a/steinbock/export/_cli/__init__.py
+++ b/steinbock/export/_cli/__init__.py
@@ -45,7 +45,6 @@ def export_cmd_group():
     show_default=True,
     help="Path to the OME-TIFF export directory",
 )
-# @check_steinbock_version
 def ome_cmd(img_dir, panel_file, ome_dir):
     panel = io.read_panel(panel_file)
     channel_names = [
@@ -100,7 +99,6 @@ def ome_cmd(img_dir, panel_file, ome_dir):
     show_default=True,
     help="Path to the histoCAT export directory",
 )
-# @check_steinbock_version
 def histocat_cmd(img_dir, mask_dir, panel_file, histocat_dir):
     panel = io.read_panel(panel_file)
     channel_names = [

--- a/steinbock/export/_cli/data.py
+++ b/steinbock/export/_cli/data.py
@@ -25,13 +25,10 @@ from steinbock.export import data
     "-o",
     "csv_file_or_dir",
     type=click.Path(),
-    default="objects.csv",
-    show_default=True,
+    required=True,
     help="Path to the CSV output file or directory",
 )
 def csv_cmd(data_dirs, concatenate, csv_file_or_dir):
-    if not concatenate and str(csv_file_or_dir) == "objects.csv":
-        csv_file_or_dir = "objects"
     if not data_dirs:
         return  # empty variadic argument, gracefully degrade into noop
     if concatenate and Path(csv_file_or_dir).is_dir():
@@ -83,13 +80,10 @@ def csv_cmd(data_dirs, concatenate, csv_file_or_dir):
     "-o",
     "fcs_file_or_dir",
     type=click.Path(),
-    default="objects.fcs",
-    show_default=True,
+    required=True,
     help="Path to the FCS output file or directory",
 )
 def fcs_cmd(data_dirs, concatenate, fcs_file_or_dir):
-    if not concatenate and str(fcs_file_or_dir) == "objects.fcs":
-        fcs_file_or_dir = "objects"
     if not data_dirs:
         return  # empty variadic argument, gracefully degrade into noop
     if concatenate and Path(fcs_file_or_dir).is_dir():
@@ -188,8 +182,7 @@ def fcs_cmd(data_dirs, concatenate, fcs_file_or_dir):
     "-o",
     "anndata_file_or_dir",
     type=click.Path(),
-    default="objects.h5ad",
-    show_default=True,
+    required=True,
     help="Path to the AnnData output file or directory",
 )
 def anndata_cmd(
@@ -229,8 +222,6 @@ def anndata_cmd(
     else:
         raise NotImplementedError()
 
-    if not concatenate and str(anndata_file_or_dir) == "objects.h5ad":
-        anndata_file_or_dir = "objects"
     intensities_files = io.list_data_files(intensities_dir)
     data_file_lists = [
         io.list_data_files(data_dir, base_files=intensities_files)

--- a/steinbock/export/_cli/data.py
+++ b/steinbock/export/_cli/data.py
@@ -251,8 +251,7 @@ def anndata_cmd(
         return click.echo("ERROR: Output directory is a file", file=sys.stderr)
     if concatenate:
         click.echo(
-            "WARNING: The anndata package currently does not support on-disk "
-            "concatenation (https://github.com/theislab/anndata/issues/312); "
+            "WARNING: The anndata package currently does not support on-disk; "
             "all files will be loaded into memory"
         )
     else:

--- a/steinbock/export/_cli/data.py
+++ b/steinbock/export/_cli/data.py
@@ -7,7 +7,6 @@ from fcswrite import write_fcs
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import check_steinbock_version
 from steinbock.export import data
 
 
@@ -30,7 +29,7 @@ from steinbock.export import data
     show_default=True,
     help="Path to the CSV output file or directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def csv_cmd(data_dirs, concatenate, csv_file_or_dir):
     if not data_dirs:
         return  # empty variadic argument, gracefully degrade into noop
@@ -87,7 +86,7 @@ def csv_cmd(data_dirs, concatenate, csv_file_or_dir):
     show_default=True,
     help="Path to the FCS output file or directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def fcs_cmd(data_dirs, concatenate, fcs_file_or_dir):
     if not data_dirs:
         return  # empty variadic argument, gracefully degrade into noop
@@ -191,7 +190,7 @@ def fcs_cmd(data_dirs, concatenate, fcs_file_or_dir):
     show_default=True,
     help="Path to the AnnData output file or directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def anndata_cmd(
     intensities_dir,
     data_dirs,

--- a/steinbock/export/_cli/data.py
+++ b/steinbock/export/_cli/data.py
@@ -30,6 +30,8 @@ from steinbock.export import data
     help="Path to the CSV output file or directory",
 )
 def csv_cmd(data_dirs, concatenate, csv_file_or_dir):
+    if not concatenate and str(csv_file_or_dir) == "objects.csv":
+        csv_file_or_dir = "objects"
     if not data_dirs:
         return  # empty variadic argument, gracefully degrade into noop
     if concatenate and Path(csv_file_or_dir).is_dir():
@@ -86,6 +88,8 @@ def csv_cmd(data_dirs, concatenate, csv_file_or_dir):
     help="Path to the FCS output file or directory",
 )
 def fcs_cmd(data_dirs, concatenate, fcs_file_or_dir):
+    if not concatenate and str(fcs_file_or_dir) == "objects.fcs":
+        fcs_file_or_dir = "objects"
     if not data_dirs:
         return  # empty variadic argument, gracefully degrade into noop
     if concatenate and Path(fcs_file_or_dir).is_dir():
@@ -225,6 +229,8 @@ def anndata_cmd(
     else:
         raise NotImplementedError()
 
+    if not concatenate and str(anndata_file_or_dir) == "objects.h5ad":
+        anndata_file_or_dir = "objects"
     intensities_files = io.list_data_files(intensities_dir)
     data_file_lists = [
         io.list_data_files(data_dir, base_files=intensities_files)

--- a/steinbock/export/_cli/data.py
+++ b/steinbock/export/_cli/data.py
@@ -29,7 +29,6 @@ from steinbock.export import data
     show_default=True,
     help="Path to the CSV output file or directory",
 )
-# @check_steinbock_version
 def csv_cmd(data_dirs, concatenate, csv_file_or_dir):
     if not data_dirs:
         return  # empty variadic argument, gracefully degrade into noop
@@ -86,7 +85,6 @@ def csv_cmd(data_dirs, concatenate, csv_file_or_dir):
     show_default=True,
     help="Path to the FCS output file or directory",
 )
-# @check_steinbock_version
 def fcs_cmd(data_dirs, concatenate, fcs_file_or_dir):
     if not data_dirs:
         return  # empty variadic argument, gracefully degrade into noop
@@ -190,7 +188,6 @@ def fcs_cmd(data_dirs, concatenate, fcs_file_or_dir):
     show_default=True,
     help="Path to the AnnData output file or directory",
 )
-# @check_steinbock_version
 def anndata_cmd(
     intensities_dir,
     data_dirs,

--- a/steinbock/export/_cli/graphs.py
+++ b/steinbock/export/_cli/graphs.py
@@ -39,7 +39,6 @@ from steinbock.export import graphs
     show_default=True,
     help="Path to the networkx output directory",
 )
-# @check_steinbock_version
 def graphs_cmd(neighbors_dir, data_dirs, graph_format, graph_dir):
     neighbors_files = io.list_neighbors_files(neighbors_dir)
     data_file_lists = [

--- a/steinbock/export/_cli/graphs.py
+++ b/steinbock/export/_cli/graphs.py
@@ -4,7 +4,6 @@ import networkx as nx
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import check_steinbock_version
 from steinbock.export import graphs
 
 
@@ -40,7 +39,7 @@ from steinbock.export import graphs
     show_default=True,
     help="Path to the networkx output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def graphs_cmd(neighbors_dir, data_dirs, graph_format, graph_dir):
     neighbors_files = io.list_neighbors_files(neighbors_dir)
     data_file_lists = [

--- a/steinbock/measurement/_cli/cellprofiler.py
+++ b/steinbock/measurement/_cli/cellprofiler.py
@@ -7,7 +7,6 @@ from tifffile import imwrite
 
 from steinbock import io
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import cellprofiler_binary, cellprofiler_plugin_dir
 from steinbock.measurement import cellprofiler
 
 
@@ -63,7 +62,6 @@ def cellprofiler_cmd_group():
     show_default=True,
     help="Path to the CellProfiler input directory",
 )
-# @check_steinbock_version
 def prepare_cmd(
     img_dir,
     mask_dir,
@@ -99,6 +97,22 @@ def prepare_cmd(
     name="run", help="Run an object measurement batch using CellProfiler"
 )
 @click.option(
+    "--cellprofiler",
+    "cellprofiler_binary",
+    type=click.STRING,
+    default="cellprofiler",
+    show_default=True,
+    help="CellProfiler binary",
+)
+@click.option(
+    "--plugins-directory",
+    "cellprofiler_plugin_dir",
+    type=click.Path(file_okay=False),
+    default="/opt/cellprofiler_plugins",
+    show_default=True,
+    help="Path to the CellProfiler plugin directory",
+)
+@click.option(
     "--pipe",
     "measurement_pipeline_file",
     type=click.Path(exists=True, dir_okay=False),
@@ -122,8 +136,13 @@ def prepare_cmd(
     show_default=True,
     help="Path to the CellProfiler output directory",
 )
-# @check_steinbock_version
-def run_cmd(measurement_pipeline_file, cpdata_dir, cpout_dir):
+def run_cmd(
+    cellprofiler_binary,
+    cellprofiler_plugin_dir,
+    measurement_pipeline_file,
+    cpdata_dir,
+    cpout_dir,
+):
     Path(cpout_dir).mkdir(exist_ok=True)
     result = cellprofiler.try_measure_objects(
         cellprofiler_binary,

--- a/steinbock/measurement/_cli/cellprofiler.py
+++ b/steinbock/measurement/_cli/cellprofiler.py
@@ -31,7 +31,7 @@ def cellprofiler_cmd_group():
     help="Path to the image directory",
 )
 @click.option(
-    "--mask",
+    "--masks",
     "mask_dir",
     type=click.Path(exists=True, file_okay=False),
     default="masks",

--- a/steinbock/measurement/_cli/cellprofiler.py
+++ b/steinbock/measurement/_cli/cellprofiler.py
@@ -7,11 +7,7 @@ from tifffile import imwrite
 
 from steinbock import io
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import (
-    cellprofiler_binary,
-    cellprofiler_plugin_dir,
-    check_steinbock_version,
-)
+from steinbock._env import cellprofiler_binary, cellprofiler_plugin_dir
 from steinbock.measurement import cellprofiler
 
 
@@ -67,7 +63,7 @@ def cellprofiler_cmd_group():
     show_default=True,
     help="Path to the CellProfiler input directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def prepare_cmd(
     img_dir,
     mask_dir,
@@ -126,7 +122,7 @@ def prepare_cmd(
     show_default=True,
     help="Path to the CellProfiler output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def run_cmd(measurement_pipeline_file, cpdata_dir, cpout_dir):
     Path(cpout_dir).mkdir(exist_ok=True)
     result = cellprofiler.try_measure_objects(

--- a/steinbock/measurement/_cli/intensities.py
+++ b/steinbock/measurement/_cli/intensities.py
@@ -30,7 +30,7 @@ _intensity_aggregations = {
     help="Path to the image directory",
 )
 @click.option(
-    "--mask",
+    "--masks",
     "mask_dir",
     type=click.Path(exists=True, file_okay=False),
     default="masks",

--- a/steinbock/measurement/_cli/intensities.py
+++ b/steinbock/measurement/_cli/intensities.py
@@ -3,7 +3,6 @@ import click
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import check_steinbock_version
 from steinbock.measurement.intensities import (
     IntensityAggregation,
     try_measure_intensities_from_disk,
@@ -64,7 +63,7 @@ _intensity_aggregations = {
     show_default=True,
     help="Path to the object intensities output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def intensities_cmd(
     img_dir, mask_dir, panel_file, intensity_aggregation_name, intensities_dir
 ):

--- a/steinbock/measurement/_cli/intensities.py
+++ b/steinbock/measurement/_cli/intensities.py
@@ -63,7 +63,6 @@ _intensity_aggregations = {
     show_default=True,
     help="Path to the object intensities output directory",
 )
-# @check_steinbock_version
 def intensities_cmd(
     img_dir, mask_dir, panel_file, intensity_aggregation_name, intensities_dir
 ):

--- a/steinbock/measurement/_cli/neighbors.py
+++ b/steinbock/measurement/_cli/neighbors.py
@@ -58,7 +58,6 @@ _neighborhood_types = {
     show_default=True,
     help="Path to the object neighbors output directory",
 )
-# @check_steinbock_version
 def neighbors_cmd(
     mask_dir, neighborhood_type_name, metric, dmax, kmax, neighbors_dir
 ):

--- a/steinbock/measurement/_cli/neighbors.py
+++ b/steinbock/measurement/_cli/neighbors.py
@@ -3,7 +3,6 @@ import click
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import check_steinbock_version
 from steinbock.measurement.neighbors import (
     NeighborhoodType,
     try_measure_neighbors_from_disk,
@@ -59,7 +58,7 @@ _neighborhood_types = {
     show_default=True,
     help="Path to the object neighbors output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def neighbors_cmd(
     mask_dir, neighborhood_type_name, metric, dmax, kmax, neighbors_dir
 ):

--- a/steinbock/measurement/_cli/regionprops.py
+++ b/steinbock/measurement/_cli/regionprops.py
@@ -16,7 +16,7 @@ from steinbock.measurement.regionprops import try_measure_regionprops_from_disk
     help="Path to the image directory",
 )
 @click.option(
-    "--mask",
+    "--masks",
     "mask_dir",
     type=click.Path(exists=True, file_okay=False),
     default="masks",

--- a/steinbock/measurement/_cli/regionprops.py
+++ b/steinbock/measurement/_cli/regionprops.py
@@ -3,7 +3,6 @@ import click
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import check_steinbock_version
 from steinbock.measurement.regionprops import try_measure_regionprops_from_disk
 
 
@@ -33,7 +32,7 @@ from steinbock.measurement.regionprops import try_measure_regionprops_from_disk
     show_default=True,
     help="Path to the object region properties output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def regionprops_cmd(img_dir, mask_dir, skimage_regionprops, regionprops_dir):
     img_files = io.list_image_files(img_dir)
     mask_files = io.list_mask_files(mask_dir, base_files=img_files)

--- a/steinbock/measurement/_cli/regionprops.py
+++ b/steinbock/measurement/_cli/regionprops.py
@@ -32,7 +32,6 @@ from steinbock.measurement.regionprops import try_measure_regionprops_from_disk
     show_default=True,
     help="Path to the object region properties output directory",
 )
-# @check_steinbock_version
 def regionprops_cmd(img_dir, mask_dir, skimage_regionprops, regionprops_dir):
     img_files = io.list_image_files(img_dir)
     mask_files = io.list_mask_files(mask_dir, base_files=img_files)

--- a/steinbock/measurement/cellprofiler/_cellprofiler.py
+++ b/steinbock/measurement/cellprofiler/_cellprofiler.py
@@ -37,7 +37,9 @@ def try_measure_objects(
         "-o",
         str(cpout_dir),
     ]
-    if cellprofiler_plugin_dir is not None:
-        args.append("--plugins-directory")
-        args.append(str(cellprofiler_plugin_dir))
+    if (
+        cellprofiler_plugin_dir is not None
+        and Path(cellprofiler_plugin_dir).exists()
+    ):
+        args.append(f"--plugins-directory={cellprofiler_plugin_dir}")
     return run_captured(args)

--- a/steinbock/preprocessing/_cli/external.py
+++ b/steinbock/preprocessing/_cli/external.py
@@ -36,7 +36,6 @@ def external_cmd_group():
     show_default=True,
     help="Path to the panel output file",
 )
-# @check_steinbock_version
 def panel_cmd(ext_img_dir, panel_file):
     ext_img_files = external.list_image_files(ext_img_dir)
     panel = external.create_panel_from_image_files(ext_img_files)
@@ -76,7 +75,6 @@ def panel_cmd(ext_img_dir, panel_file):
     show_default=True,
     help="Path to the image information output file",
 )
-# @check_steinbock_version
 def images_cmd(ext_img_dir, panel_file, img_dir, image_info_file):
     channel_indices = None
     if Path(panel_file).exists():

--- a/steinbock/preprocessing/_cli/external.py
+++ b/steinbock/preprocessing/_cli/external.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from steinbock import io
 from steinbock.preprocessing import external
 from steinbock._cli import OrderedClickGroup
-from steinbock._env import check_steinbock_version
 
 
 @click.group(
@@ -37,7 +36,7 @@ def external_cmd_group():
     show_default=True,
     help="Path to the panel output file",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def panel_cmd(ext_img_dir, panel_file):
     ext_img_files = external.list_image_files(ext_img_dir)
     panel = external.create_panel_from_image_files(ext_img_files)
@@ -77,7 +76,7 @@ def panel_cmd(ext_img_dir, panel_file):
     show_default=True,
     help="Path to the image information output file",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def images_cmd(ext_img_dir, panel_file, img_dir, image_info_file):
     channel_indices = None
     if Path(panel_file).exists():

--- a/steinbock/preprocessing/_cli/imc.py
+++ b/steinbock/preprocessing/_cli/imc.py
@@ -91,7 +91,6 @@ def imc_cmd_group():
     show_default=True,
     help="Path to the panel output file",
 )
-# @check_steinbock_version
 def panel_cmd(
     imc_panel_file,
     imc_panel_channel_col,
@@ -182,7 +181,6 @@ def panel_cmd(
     show_default=True,
     help="Path to the image information output file",
 )
-# @check_steinbock_version
 def images_cmd(
     mcd_dir, txt_dir, unzip, panel_file, hpf, img_dir, image_info_file
 ):

--- a/steinbock/preprocessing/_cli/imc.py
+++ b/steinbock/preprocessing/_cli/imc.py
@@ -9,7 +9,6 @@ from zipfile import ZipFile
 
 from steinbock import io
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import check_steinbock_version
 from steinbock.preprocessing import imc
 
 
@@ -71,7 +70,7 @@ def imc_cmd_group():
 @click.option(
     "--mcd",
     "mcd_dir",
-    type=click.Path(exists=True, file_okay=False),
+    type=click.Path(file_okay=False),
     default="raw",
     show_default=True,
     help="Path to the IMC .mcd file directory",
@@ -79,7 +78,7 @@ def imc_cmd_group():
 @click.option(
     "--txt",
     "txt_dir",
-    type=click.Path(exists=True, file_okay=False),
+    type=click.Path(file_okay=False),
     default="raw",
     show_default=True,
     help="Path to the IMC .txt file directory",
@@ -92,7 +91,7 @@ def imc_cmd_group():
     show_default=True,
     help="Path to the panel output file",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def panel_cmd(
     imc_panel_file,
     imc_panel_channel_col,
@@ -183,7 +182,7 @@ def panel_cmd(
     show_default=True,
     help="Path to the image information output file",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def images_cmd(
     mcd_dir, txt_dir, unzip, panel_file, hpf, img_dir, image_info_file
 ):

--- a/steinbock/preprocessing/imc.py
+++ b/steinbock/preprocessing/imc.py
@@ -86,11 +86,11 @@ def create_panel_from_imc_panel(
         if "ilastik" in panel:
             panel.loc[g.index, "ilastik"] = g["ilastik"].any()
     panel = panel.groupby(panel["channel"].values).aggregate("first")
-    if "ilastik" in panel:
-        ilastik_mask = panel["ilastik"].astype(bool)
-        panel["ilastik"] = pd.Series(dtype=pd.UInt8Dtype())
-        panel.loc[ilastik_mask, "ilastik"] = range(1, ilastik_mask.sum() + 1)
-    return _clean_panel(panel)
+    panel = _clean_panel(panel)  # ilastik column may be nullable uint8 now
+    ilastik_mask = panel["ilastik"].fillna(False).astype(bool)
+    panel["ilastik"] = pd.Series(dtype=pd.UInt8Dtype())
+    panel.loc[ilastik_mask, "ilastik"] = range(1, ilastik_mask.sum() + 1)
+    return panel
 
 
 def create_panel_from_mcd_files(

--- a/steinbock/segmentation/_cli/cellprofiler.py
+++ b/steinbock/segmentation/_cli/cellprofiler.py
@@ -4,11 +4,7 @@ import sys
 from pathlib import Path
 
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import (
-    cellprofiler_binary,
-    cellprofiler_plugin_dir,
-    check_steinbock_version,
-)
+from steinbock._env import cellprofiler_binary, cellprofiler_plugin_dir
 from steinbock.segmentation import cellprofiler
 
 
@@ -32,7 +28,7 @@ def cellprofiler_cmd_group():
     show_default=True,
     help="Path to the CellProfiler segmentation pipeline output file",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def prepare_cmd(segmentation_pipeline_file):
     cellprofiler.create_and_save_segmentation_pipeline(
         segmentation_pipeline_file
@@ -66,7 +62,7 @@ def prepare_cmd(segmentation_pipeline_file):
     show_default=True,
     help="Path to the mask output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def run_cmd(segmentation_pipeline_file, probabilities_dir, mask_dir):
     if probabilities_dir not in ("ilastik_probabilities"):
         click.echo(

--- a/steinbock/segmentation/_cli/cellprofiler.py
+++ b/steinbock/segmentation/_cli/cellprofiler.py
@@ -61,7 +61,7 @@ def prepare_cmd(segmentation_pipeline_file):
     help="Path to the CellProfiler segmentation pipeline file",
 )
 @click.option(
-    "--probab",
+    "--probabs",
     "probabilities_dir",
     type=click.Path(exists=True, file_okay=False),
     default="ilastik_probabilities",

--- a/steinbock/segmentation/_cli/cellprofiler.py
+++ b/steinbock/segmentation/_cli/cellprofiler.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import cellprofiler_binary, cellprofiler_plugin_dir
 from steinbock.segmentation import cellprofiler
 
 
@@ -28,7 +27,6 @@ def cellprofiler_cmd_group():
     show_default=True,
     help="Path to the CellProfiler segmentation pipeline output file",
 )
-# @check_steinbock_version
 def prepare_cmd(segmentation_pipeline_file):
     cellprofiler.create_and_save_segmentation_pipeline(
         segmentation_pipeline_file
@@ -37,6 +35,22 @@ def prepare_cmd(segmentation_pipeline_file):
 
 @cellprofiler_cmd_group.command(
     name="run", help="Run a object segmentation batch using CellProfiler"
+)
+@click.option(
+    "--cellprofiler",
+    "cellprofiler_binary",
+    type=click.STRING,
+    default="cellprofiler",
+    show_default=True,
+    help="CellProfiler binary",
+)
+@click.option(
+    "--plugins-directory",
+    "cellprofiler_plugin_dir",
+    type=click.Path(file_okay=False),
+    default="/opt/cellprofiler_plugins",
+    show_default=True,
+    help="Path to the CellProfiler plugin directory",
 )
 @click.option(
     "--pipe",
@@ -62,8 +76,13 @@ def prepare_cmd(segmentation_pipeline_file):
     show_default=True,
     help="Path to the mask output directory",
 )
-# @check_steinbock_version
-def run_cmd(segmentation_pipeline_file, probabilities_dir, mask_dir):
+def run_cmd(
+    cellprofiler_binary,
+    cellprofiler_plugin_dir,
+    segmentation_pipeline_file,
+    probabilities_dir,
+    mask_dir,
+):
     if probabilities_dir not in ("ilastik_probabilities"):
         click.echo(
             "WARNING: When using custom probabilities from unknown origins, "

--- a/steinbock/segmentation/_cli/deepcell.py
+++ b/steinbock/segmentation/_cli/deepcell.py
@@ -4,7 +4,7 @@ import numpy as np
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import check_steinbock_version, keras_models_dir
+from steinbock._env import keras_models_dir
 from steinbock.segmentation import deepcell
 
 if deepcell.deepcell_available:
@@ -121,7 +121,7 @@ _applications = {
     show_default=True,
     help="Path to the mask output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def deepcell_cmd(
     application_name,
     model_path_or_name,

--- a/steinbock/segmentation/_cli/deepcell.py
+++ b/steinbock/segmentation/_cli/deepcell.py
@@ -4,7 +4,6 @@ import numpy as np
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import keras_models_dir
 from steinbock.segmentation import deepcell
 
 if deepcell.deepcell_available:
@@ -13,10 +12,6 @@ else:
     yaml = None
 
 deepcell_cli_available = deepcell.deepcell_available
-
-_model_paths = {}
-if Path(keras_models_dir).is_dir():
-    _model_paths.update({x.name: x for x in Path(keras_models_dir).iterdir()})
 
 _applications = {
     "mesmer": deepcell.Application.MESMER,
@@ -41,10 +36,15 @@ _applications = {
     type=click.STRING,
     default="MultiplexSegmentation",
     show_default=True,
-    help=(
-        "Path to custom Keras model or name of Keras model stored in "
-        f"{keras_models_dir} [{', '.join(_model_paths.keys())}]"
-    ),
+    help="Path/name of custom Keras model",
+)
+@click.option(
+    "--modeldir",
+    "keras_model_dir",
+    type=click.Path(file_okay=False),
+    default="/opt/keras/models",
+    show_default=True,
+    help="Path to Keras model directory",
 )
 @click.option(
     "--img",
@@ -121,10 +121,10 @@ _applications = {
     show_default=True,
     help="Path to the mask output directory",
 )
-# @check_steinbock_version
 def deepcell_cmd(
     application_name,
     model_path_or_name,
+    keras_model_dir,
     img_dir,
     channelwise_minmax,
     channelwise_zscore,
@@ -149,8 +149,11 @@ def deepcell_cmd(
 
         if Path(model_path_or_name).exists():
             model = load_model(model_path_or_name, compile=False)
-        elif model_path_or_name in _model_paths:
-            model = load_model(_model_paths[model_path_or_name], compile=False)
+        elif Path(keras_model_dir).joinpath(model_path_or_name).exists():
+            model = load_model(
+                Path(keras_model_dir).joinpath(model_path_or_name),
+                compile=False,
+            )
     preprocess_kwargs = None
     if preprocess_file is not None:
         with Path(preprocess_file).open() as f:

--- a/steinbock/segmentation/cellprofiler/_cellprofiler.py
+++ b/steinbock/segmentation/cellprofiler/_cellprofiler.py
@@ -37,7 +37,9 @@ def try_segment_objects(
         "-o",
         str(mask_dir),
     ]
-    if cellprofiler_plugin_dir is not None:
-        args.append("--plugins-directory")
-        args.append(str(cellprofiler_plugin_dir))
+    if (
+        cellprofiler_plugin_dir is not None
+        and Path(cellprofiler_plugin_dir).exists()
+    ):
+        args.append(f"--plugins-directory={cellprofiler_plugin_dir}")
     return run_captured(args)

--- a/steinbock/utils/_cli/matching.py
+++ b/steinbock/utils/_cli/matching.py
@@ -3,7 +3,6 @@ import click
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import check_steinbock_version
 from steinbock.utils import matching
 
 
@@ -21,7 +20,7 @@ from steinbock.utils import matching
     required=True,
     help="Path to the object table CSV output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def match_cmd(masks1, masks2, csv_dir):
     if Path(masks1).is_file() and Path(masks2).is_file():
         mask_files1 = [Path(masks1)]

--- a/steinbock/utils/_cli/matching.py
+++ b/steinbock/utils/_cli/matching.py
@@ -20,7 +20,6 @@ from steinbock.utils import matching
     required=True,
     help="Path to the object table CSV output directory",
 )
-# @check_steinbock_version
 def match_cmd(masks1, masks2, csv_dir):
     if Path(masks1).is_file() and Path(masks2).is_file():
         mask_files1 = [Path(masks1)]

--- a/steinbock/utils/_cli/mosaics.py
+++ b/steinbock/utils/_cli/mosaics.py
@@ -41,7 +41,6 @@ def mosaics_cmd_group():
     required=True,
     help="Path to the tile output directory",
 )
-# @check_steinbock_version
 def tile_cmd(images, tile_size, tile_dir):
     img_files = _collect_img_files(images)
     Path(tile_dir).mkdir(exist_ok=True)
@@ -66,7 +65,6 @@ def tile_cmd(images, tile_size, tile_dir):
     required=True,
     help="Path to the tile output directory",
 )
-# @check_steinbock_version
 def stitch_cmd(tiles, img_dir):
     tile_info_groups = {}
     tile_files = _collect_img_files(tiles)

--- a/steinbock/utils/_cli/mosaics.py
+++ b/steinbock/utils/_cli/mosaics.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from steinbock import io
 from steinbock._cli.utils import OrderedClickGroup
-from steinbock._env import check_steinbock_version
 from steinbock.utils import mosaics
 
 
@@ -42,7 +41,7 @@ def mosaics_cmd_group():
     required=True,
     help="Path to the tile output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def tile_cmd(images, tile_size, tile_dir):
     img_files = _collect_img_files(images)
     Path(tile_dir).mkdir(exist_ok=True)
@@ -67,7 +66,7 @@ def tile_cmd(images, tile_size, tile_dir):
     required=True,
     help="Path to the tile output directory",
 )
-@check_steinbock_version
+# @check_steinbock_version
 def stitch_cmd(tiles, img_dir):
     tile_info_groups = {}
     tile_files = _collect_img_files(tiles)

--- a/tests/classification/test_ilastik_classification.py
+++ b/tests/classification/test_ilastik_classification.py
@@ -5,8 +5,9 @@ import shutil
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import ilastik_binary
 from steinbock.classification import ilastik
+
+ilastik_binary = "/opt/ilastik/run_ilastik.sh"
 
 
 class TestIlastikClassification:

--- a/tests/measurement/test_cellprofiler_measurement.py
+++ b/tests/measurement/test_cellprofiler_measurement.py
@@ -3,8 +3,10 @@ import shutil
 
 from pathlib import Path
 
-from steinbock._env import cellprofiler_binary, cellprofiler_plugin_dir
 from steinbock.measurement import cellprofiler
+
+cellprofiler_binary = "cellprofiler"
+cellprofiler_plugin_dir = "/opt/cellprofiler_plugins"
 
 
 class TestCellprofilerMeasurement:

--- a/tests/segmentation/test_cellprofiler_segmentation.py
+++ b/tests/segmentation/test_cellprofiler_segmentation.py
@@ -3,8 +3,10 @@ import shutil
 
 from pathlib import Path
 
-from steinbock._env import cellprofiler_binary, cellprofiler_plugin_dir
 from steinbock.segmentation import cellprofiler
+
+cellprofiler_binary = "cellprofiler"
+cellprofiler_plugin_dir = "/opt/cellprofiler_plugins"
 
 
 class TestCellprofilerSegmentation:

--- a/tests/segmentation/test_deepcell_segmentation.py
+++ b/tests/segmentation/test_deepcell_segmentation.py
@@ -4,9 +4,10 @@ import pytest
 from pathlib import Path
 
 from steinbock import io
-from steinbock._env import keras_models_dir
 from steinbock.segmentation import deepcell
 from steinbock.segmentation.deepcell import Application
+
+keras_models_dir = "/opt/keras/models"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
  - Removed steinbock version check
  - Fix IMC panel preprocessing (channel order)
  - Make CLI usable when using PyPI package install
  - Renamed `--mask` and `--probab` parameters to `--masks` and `--probabs`, respectively 
  - Clean histoCAT export file names
  - Required `-o` parameter for data export