### PR TITLE
Enhanced error handling of corrupted IMC files with no recovery txt

### DIFF
--- a/steinbock/preprocessing/imc.py
+++ b/steinbock/preprocessing/imc.py
@@ -401,7 +401,9 @@ def _try_preprocess_mcd_images_from_disk(
                                             )
                                             del img
                         else:
-                            logger.warning(f"No corresponding recovery text file was found for acquisition {acquisition.id} in file {mcd_file}")
+                            logger.warning(
+                                f"No corresponding recovery text file was found for acquisition {acquisition.id} in file {mcd_file}"
+                            )
 
     except Exception as e:
         logger.exception(f"Error reading file {mcd_file}: {e}")

--- a/steinbock/preprocessing/imc.py
+++ b/steinbock/preprocessing/imc.py
@@ -401,8 +401,7 @@ def _try_preprocess_mcd_images_from_disk(
                                             )
                                             del img
                         else:
-                            logger.warning(f"No recovery text file was found")
-                            continue
+                            logger.warning(f"No corresponding recovery text file was found for acquisition {acquisition.id} in file {mcd_file}")
 
     except Exception as e:
         logger.exception(f"Error reading file {mcd_file}: {e}")

--- a/steinbock/preprocessing/imc.py
+++ b/steinbock/preprocessing/imc.py
@@ -400,6 +400,10 @@ def _try_preprocess_mcd_images_from_disk(
                                                 True,
                                             )
                                             del img
+                        else:
+                            logger.warning(f"No recovery text file was found")
+                            continue
+
     except Exception as e:
         logger.exception(f"Error reading file {mcd_file}: {e}")
 


### PR DESCRIPTION
AS discussed in #184, now when an mcd file is corrupted and a recovery txt file is not found, an additional warning message is logged: "No corresponding recovery text file was found". I tested it using the corrupted mcd file provided by @nathansteenbuck.